### PR TITLE
Example 3 country picker

### DIFF
--- a/app/assets/data/dummy-picker-data-1.json
+++ b/app/assets/data/dummy-picker-data-1.json
@@ -1,0 +1,328 @@
+{
+    "country:gb": {
+        "names": {
+            "en-GB": "United Kingdom",
+            "cy": "Deyrnas Unedig"
+        },
+        "meta": {
+            "canonical": true,
+            "canonical-mask": 1,
+            "stable-name": true
+        },
+        "edges": {
+            "from": []
+        }
+    },
+    "synonym:gb:gb": {
+        "names": {
+            "en-GB": "gb"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["country:gb"]
+        }
+    },
+    "synonym:gb:uk": {
+        "names": {
+            "en-GB": "uk"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["country:gb"]
+        }
+    },
+    "uk:nir": {
+        "names": {
+            "en-GB": "Northern Ireland",
+            "cy": "Gogledd Iwerddon"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": true
+        },
+        "edges": {
+            "from": ["country:gb"]
+        }
+    },
+    "synonym:nir:nir": {
+        "names": {
+            "en-GB": "nir"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["uk:nir"]
+        }
+    },
+    "uk:wls": {
+        "names": {
+            "en-GB": "Wales",
+            "cy": "Cymru"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": true
+        },
+        "edges": {
+            "from": ["country:gb"]
+        }
+    },
+    "synonym:wls:wls": {
+        "names": {
+            "en-GB": "wls"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["uk:wls"]
+        }
+    },
+    "uk:sct": {
+        "names": {
+            "en-GB": "Scotland",
+            "cy": "Yr Alban"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": true
+        },
+        "edges": {
+            "from": ["country:gb"]
+        }
+    },
+    "synonym:sct:sct": {
+        "names": {
+            "en-GB": "sct"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["uk:sct"]
+        }
+    },
+    "uk:eng": {
+        "names": {
+            "en-GB": "England",
+            "cy": "Lloegr"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": true
+        },
+        "edges": {
+            "from": ["country:gb"]
+        }
+    },
+    "synonym:eng:eng": {
+        "names": {
+            "en-GB": "eng"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["uk:eng"]
+        }
+    },
+    "uk:gbn": {
+        "names": {
+            "en-GB": "Great Britain",
+            "cy": "Prydain Fawr"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": true
+        },
+        "edges": {
+            "from": ["country:gb"]
+        }
+    },
+    "synonym:gbn:gbn": {
+        "names": {
+            "en-GB": "gbn"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["uk:gbn"]
+        }
+    },
+    "territory:im": {
+        "names": {
+            "en-GB": "Isle of Man",
+            "cy": "Ynys Manaw"
+        },
+        "meta": {
+            "canonical": true,
+            "canonical-mask": 1,
+            "stable-name": true
+        },
+        "edges": {
+            "from": []
+        }
+    },
+    "territory:hk": {
+        "names": {
+            "en-GB": "Hong Kong",
+            "cy": "Hong Kong"
+        },
+        "meta": {
+            "canonical": true,
+            "canonical-mask": 1,
+            "stable-name": true
+        },
+        "edges": {
+            "from": []
+        }
+    },
+    "territory:sx": {
+        "names": {
+            "en-GB": "Sint Maarten (Dutch part)",
+            "cy": "Sint Maarten (rhan Iseldireg)"
+        },
+        "meta": {
+            "canonical": true,
+            "canonical-mask": 1,
+            "stable-name": true
+        },
+        "edges": {
+            "from": []
+        }
+    },
+    "synonym:sx:sx": {
+        "names": {
+            "en-GB": "Sint Maarten"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["territory:sx"]
+        }
+    },
+    "territory:bq-se": {
+        "names": {
+            "en-GB": "Sint Eustatius",
+            "cy": "Sint Eustatius"
+        },
+        "meta": {
+            "canonical": true,
+            "canonical-mask": 1,
+            "stable-name": true
+        },
+        "edges": {
+            "from": []
+        }
+    },
+    "territory:bat": {
+        "names": {
+            "en-GB": "British Antarctic Territory",
+            "cy": "Tiriogaeth Antarctig Prydain"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": true
+        },
+        "edges": {
+            "from": ["country:gb"]
+        }
+    },
+    "territory:bat": {
+        "names": {
+            "en-GB": "British Antarctic Territory",
+            "cy": "Tiriogaeth Antarctig Prydain"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": true
+        },
+        "edges": {
+            "from": ["country:gb"]
+        }
+    },
+    "territory:aq": {
+        "names": {
+            "en-GB": "Antarctica",
+            "cy": "Antarctica"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": true
+        },
+        "edges": {
+            "from": ["country:gb", "country:fr"]
+        }
+    },
+    "country:fr": {
+        "names": {
+            "en-GB": "France",
+            "cy": "France"
+        },
+        "meta": {
+            "canonical": true,
+            "canonical-mask": 1,
+            "stable-name": true
+        },
+        "edges": {
+            "from": []
+        }
+    },
+    "synonym:fr:fr": {
+        "names": {
+            "en-GB": "The French Republic"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["country:fr"]
+        }
+    },
+    "endonym:fr": {
+        "names": {
+            "fr-FR": "République Française"
+        },
+        "meta": {
+            "canonical": false,
+            "canonical-mask": 0,
+            "stable-name": false
+        },
+        "edges": {
+            "from": ["country:fr"]
+        }
+    }
+}

--- a/app/views/country-picker-3.html
+++ b/app/views/country-picker-3.html
@@ -1,0 +1,158 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Example - Forms
+{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+
+  <form action="/docs/tutorials-and-examples" method="post" class="form">
+
+    <h1 class="form-title heading-large">
+      Country picker
+    </h1>
+
+    <!-- Country picker -->
+     <div class="form-group">
+      <label class="form-label-bold" for="country-select-box">Country</label>
+      <input type="text" class="form-control" id="country-select-box" placeholder="Country">
+    </div>
+
+    <div class="form-group">
+      <input type="submit" class="button" value="Continue">
+    </div>
+
+  </form>
+
+</main>
+{% endblock %}
+
+{% block body_end %}
+  <!-- Javascript -->
+  <script src="/public/javascripts/details.polyfill.js"></script>
+  <script src="/public/javascripts/jquery-1.11.3.js"></script>
+  <script src="/public/javascripts/govuk/selection-buttons.js"></script>
+  <script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
+  <script src="/public/javascripts/govuk/show-hide-content.js"></script>
+  <script src="/public/javascripts/application.js"></script>
+  <!-- GOV.UK Prototype kit {{releaseVersion}} -->
+
+  <script src="/public/typeahead.bundle.min.js"></script>
+  <script src="https://unpkg.com/lodash@4.17.4" type="text/javascript"></script>
+
+  <script type="text/javascript">
+    $(document).ready(function () {
+      var preferredLocale = 'en-GB'
+
+      $.get('/public/data/dummy-picker-data-1.json', (graph) => {
+        // This is a map that takes a name and returns its node and locale.
+        // Examples:
+        //   reverseMap['United Kingdom']   === { node: {country:gb}, locale: 'en-GB' }
+        //   reverseMap['uk']               === { node: {synonym:gb:gb}, locale: 'en-GB' }
+        //   reverseMap['Northern Ireland'] === { node: {uk:nir}, locale: 'en-GB' }
+        //   reverseMap['Gogledd Iwerddon'] === { node: {uk:nir}, locale: 'cy' }
+        var reverseMap = Object.keys(graph)
+          .reduce((revMap, curie) => {
+            var node = graph[curie]
+            Object.keys(node.names).forEach(locale => {
+              var name = node.names[locale]
+              // HACK to prevent overriding for example Antarctica,
+              // where the en-GB and cy names are identical, and we want
+              // en-GB to stay on top.
+              var isntDefinedOrLocaleIsEnGb = !revMap[name] || locale === preferredLocale
+              if (isntDefinedOrLocaleIsEnGb) {
+                revMap[name] = { node, locale }
+              }
+            })
+            return revMap
+          }, {})
+
+        function isCanonicalNode (node) {
+          return node.meta.canonical
+        }
+
+        function presentableName (node, locale) {
+          var requestedName = node['names'][locale]
+          var fallback = Object.values(node['names'])[0]
+          return requestedName || fallback
+        }
+
+        // Given a starting node and the locale with which it was reached, this is a
+        // recursive function that will search the graph to find the canonical node(s).
+        function findCanonicalNodeWithPath (node, locale, path) {
+          if (locale === preferredLocale) {
+            if (isCanonicalNode(node)) {
+              // We found it.
+              return [{ node, locale: preferredLocale, path }]
+            } else {
+              // Get all the linked nodes.
+              var linkedNodes = node.edges.from.map(nodeFromCurie => graph[nodeFromCurie])
+              // Find the canonical nodes for each one of them.
+              return linkedNodes.reduce((canonicalNodes, linkedNode) =>{
+                return canonicalNodes.concat(findCanonicalNodeWithPath(
+                  linkedNode,
+                  preferredLocale,
+                  path.concat([{ node, locale: preferredLocale }])
+                ))
+              }, [])
+            }
+          } else {
+            // If not the preferredLocale, add a hop to the path while we switch
+            // to the preferredLocale.
+            return findCanonicalNodeWithPath(
+              node,
+              preferredLocale,
+              path.concat([{ node, locale }])
+            )
+          }
+        }
+
+        // Bloodhound gives us back a list of results that includes synonyms, typos,
+        // endonyms and other things we don't want the user to see.
+        // This function transforms those into a list of stable canonical country names.
+        function presentResults (rawResults) {
+          var nodesWithLocales = rawResults.map(r => reverseMap[r])
+
+          var canonicalNodesWithPaths = nodesWithLocales.reduce((canonicalNodes, nwl) => {
+            return canonicalNodes.concat(findCanonicalNodeWithPath(nwl.node, nwl.locale, []))
+          }, [])
+
+          var presentableNodes = _.uniq(
+            canonicalNodesWithPaths.map(cnwp => {
+              var canonicalName = presentableName(cnwp.node, preferredLocale)
+              var pathToName = ''
+              if (cnwp.path.length) {
+                var stableNamesInPath = cnwp.path.map(pathNode => presentableName(pathNode.node, pathNode.locale))
+                pathToName = ` (path: ${stableNamesInPath.join(' > ')})`
+              }
+              return `${canonicalName}${pathToName}`
+            })
+          )
+
+          return presentableNodes
+        }
+
+        // The keys of the reverseMap represent all the names/synonyms/endonyms, so
+        // we use them as the seed data for Bloodhound.
+        var seed = Object.keys(reverseMap)
+        var countries = new Bloodhound({
+          datumTokenizer: Bloodhound.tokenizers.nonword,
+          queryTokenizer: Bloodhound.tokenizers.whitespace,
+          local: seed
+        })
+
+        $('#country-select-box').typeahead({
+          hint: false
+        }, {
+          source: (query, syncResults) => {
+            countries.search(query, (rawResults) => {
+              var presentableResults = presentResults(rawResults)
+              syncResults(presentableResults)
+            })
+          }
+        })
+      })
+    })
+  </script>
+{% endblock %}

--- a/app/views/country-picker-3.html
+++ b/app/views/country-picker-3.html
@@ -14,13 +14,30 @@
     </h1>
 
     <!-- Country picker -->
-     <div class="form-group">
+    <div class="form-group">
       <label class="form-label-bold" for="country-select-box">Country</label>
       <input type="text" class="form-control" id="country-select-box" placeholder="Country">
     </div>
 
     <div class="form-group">
       <input type="submit" class="button" value="Continue">
+    </div>
+
+    <h2 class="heading-large">Debugging options</h2>
+
+    <div class="form-group">
+      <label class="form-label" for="country-select-locale">Preferred locale (will present options in this locale, where translation is available)</label>
+      <select class="form-control" id="country-select-locale">
+        <option value="en-GB" selected>English</option>
+        <option value="cy">Welsh</option>
+      </select>
+    </div>
+
+    <div class="form-group">
+      <label class="block-label selection-button-checkbox" for="country-show-paths">
+        <input id="country-show-paths" name="show-paths" type="checkbox" value="show-paths" checked>
+        Show paths (useful for debugging, will cause duplicate countries to appear where more than one path exists)
+      </label>
     </div>
 
   </form>
@@ -44,6 +61,7 @@
   <script type="text/javascript">
     $(document).ready(function () {
       var preferredLocale = 'en-GB'
+      var showPaths = true
 
       $.get('/public/data/dummy-picker-data-1.json', (graph) => {
         // This is a map that takes a name and returns its node and locale.
@@ -122,7 +140,7 @@
             canonicalNodesWithPaths.map(cnwp => {
               var canonicalName = presentableName(cnwp.node, preferredLocale)
               var pathToName = ''
-              if (cnwp.path.length) {
+              if (showPaths && cnwp.path.length) {
                 var stableNamesInPath = cnwp.path.map(pathNode => presentableName(pathNode.node, pathNode.locale))
                 pathToName = ` (path: ${stableNamesInPath.join(' > ')})`
               }
@@ -151,6 +169,14 @@
               syncResults(presentableResults)
             })
           }
+        })
+
+        $('#country-select-locale').on('change', (evt) => {
+          preferredLocale = evt.target.value
+        })
+
+        $('#country-show-paths').on('change', (evt) => {
+          showPaths = evt.target.checked
         })
       })
     })

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -34,7 +34,12 @@
 
       <h2 class="heading-medium"><a href="/country-picker-3">Example 3: jQuery Typeahead + register data file</a></h2>
 
-      <p>Coming soon.</p>
+      <p>
+        This example uses the <a href="https://github.com/corejavascript/typeahead.js" target="_blank">corejs-typeahead</a> jQuery plugin and populates it using
+        a handmade data file, based off of register data. It augments the typeahead
+        plugin and allows it to handle synonyms, translations, endonyms, and
+        territory relationships.
+      </p>
 
     </div>
   </div>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -32,7 +32,7 @@
         shelf component with a public register.
       </p>
 
-      <h2 class="heading-medium"><a href="#">Example 3: jQuery Typeahead + register data file</a></h2>
+      <h2 class="heading-medium"><a href="/country-picker-3">Example 3: jQuery Typeahead + register data file</a></h2>
 
       <p>Coming soon.</p>
 


### PR DESCRIPTION
This is a country picker that makes use of the dummy picker data from Andy.

It can do:

- synonyms/acronyms/endonyms (try: uk, gb, Britain, République)
- translations (try: Yr Alban)
- territories that belong to multiple countries (try: Antarctica)
- switching locales (switching to Welsh will display things in Welsh, where available)
- displaying the path to a final result (which can be further tweaked to be more user friendly, left verbose for now for debugging)

Known bugs:

- tokenizer splits by whitespace so searching for "Dut" doesn't give you "Sint Maarten (Dutch part)", because it wants "(Dut"

TODO:

- [x] Add homepage blurb
- [x] Replace tokenizer

# Screenshot

![screen shot 2017-01-06 at 15 40 57](https://cloud.githubusercontent.com/assets/1650875/21723234/97e00b48-d427-11e6-8111-81b658933e1d.png)
