### PR TITLE
Fix heroku and allow newer node versions

### DIFF
--- a/app/services/location-v1.js
+++ b/app/services/location-v1.js
@@ -6,7 +6,7 @@ function isCanonicalNode (node) {
 
 function presentableName (node, locale) {
   var requestedName = node['names'][locale]
-  var fallback = Object.values(node['names'])[0]
+  var fallback = Object.keys(node['names']).map(k => node['names'][k])[0]
   return requestedName || fallback
 }
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -50,7 +50,7 @@
           href="https://github.com/dwpdigitaltech/hrt-prototype/blob/master/app/assets/javascripts/modules/country-autocomplete.js"
           target="_blank"
         >DWP's implementation</a>. It also moves part of the initial data processing logic
-        server-side, has separate pages for Enlgish and Welsh, is compatible with more
+        server-side, has separate pages for English and Welsh, is compatible with more
         browsers, has some minor usability fixes, and uses a much larger dataset.
       </p>
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "5.0.1",
   "private": true,
   "engines": {
-    "node": ">=6.0 <7.0"
+    "node": ">=6.0"
   },
   "scripts": {
     "start": "node start.js",


### PR DESCRIPTION
The latest version I deployed to Heroku blew up because node v6 doesn't support `Object.values`. I've changed the code and then removed the node engine restriction.

Also fix a typo.