### PR TITLE
Passport prototype UX fixes

### DIFF
--- a/app/views/includes/location_picker.html
+++ b/app/views/includes/location_picker.html
@@ -184,6 +184,18 @@
 
       var id = 'location-select-box'
 
+      function sortExactMatchesFirst (data, query) {
+        data.sort((a, b) => a === query ? -1 : (b === query ? 1 : 0 ))
+      }
+
+      function startsWith (str, query) {
+        return str.toLowerCase().indexOf(query.toLowerCase()) === 0
+      }
+
+      function sortResultsByWordMatch (data, query) {
+        data.sort((a, b) => startsWith(a, query) ? -1 : (startsWith(b, query) ? 1 : 0))
+      }
+
       AccessibleTypeahead({
         element: container[0],
         id: id,
@@ -193,7 +205,12 @@
             syncResults([])
           } else {
             countries.search(query, (rawResults) => {
+              sortExactMatchesFirst(rawResults, query)
+
               var presentableResults = presentResults(rawResults)
+
+              sortResultsByWordMatch(presentableResults, query)
+
               syncResults(presentableResults)
             })
           }

--- a/app/views/includes/location_picker.html
+++ b/app/views/includes/location_picker.html
@@ -205,6 +205,7 @@
           if (showNoResults) {
             syncResults([])
           } else {
+            query = query.replace(/\./g,'')
             countries.search(query, (rawResults) => {
               sortExactMatchesFirst(rawResults, query)
 

--- a/app/views/includes/location_picker.html
+++ b/app/views/includes/location_picker.html
@@ -10,6 +10,7 @@
   list-style: none;
   background-color: #fff;
   border: 2px solid #6f777b;
+  border-top: 0;
 }
 
 .tt-suggestion {

--- a/app/views/includes/location_picker.html
+++ b/app/views/includes/location_picker.html
@@ -17,11 +17,10 @@
   position: relative;
   display: block;
   margin-bottom: -2px;
-  padding: 8px;
+  padding: 5px 4px 4px;
   border: solid #bfc1c3;
   border-width: 2px 0;
   font-family: "nta", Arial, sans-serif;
-  font-weight: 700;
   text-transform: none;
   font-size: 16px;
   line-height: 1.25;
@@ -40,7 +39,7 @@
   border-top-width: 0;
 }
 
-.tt-suggestion:hover, .tt-suggestion:focus {
+.tt-suggestion:focus {
   z-index: 1;
   background-color: #2b8cc4;
   border-color: #2b8cc4;

--- a/app/views/includes/location_picker.html
+++ b/app/views/includes/location_picker.html
@@ -102,7 +102,7 @@
   <script type="text/babel">
     $(document).ready(function () {
       var preferredLocale = 'en-GB'
-      var showPaths = false
+      var showPaths = true
 
       function isCanonicalNode (node) {
         return node.meta.canonical
@@ -159,8 +159,13 @@
             var canonicalName = presentableName(cnwp.node, preferredLocale)
             var pathToName = ''
             if (showPaths && cnwp.path.length) {
-              var stableNamesInPath = cnwp.path.map(pathNode => presentableName(pathNode.node, pathNode.locale))
-              pathToName = ` (path: ${stableNamesInPath.join(' > ')})`
+              var stableNamesInPath = cnwp.path
+                .filter(pathNode => pathNode.node.meta['stable-name'])
+                .map(pathNode => presentableName(pathNode.node, pathNode.locale))
+              var lastNode = stableNamesInPath.pop()
+              if (lastNode) {
+                pathToName = ` (${lastNode})`
+              }
             }
             return `${canonicalName}${pathToName}`
           })

--- a/app/views/includes/location_picker.html
+++ b/app/views/includes/location_picker.html
@@ -188,10 +188,15 @@
         element: container[0],
         id: id,
         source: (query, syncResults) => {
-          countries.search(query, (rawResults) => {
-            var presentableResults = presentResults(rawResults)
-            syncResults(presentableResults)
-          })
+          const showNoResults = query.length <= 1
+          if (showNoResults) {
+            syncResults([])
+          } else {
+            countries.search(query, (rawResults) => {
+              var presentableResults = presentResults(rawResults)
+              syncResults(presentableResults)
+            })
+          }
         }
       })
 

--- a/app/views/includes/location_picker.html
+++ b/app/views/includes/location_picker.html
@@ -87,7 +87,7 @@
 
   <script src="https://unpkg.com/ua-parser-js@0.7.12"></script>
   <script src="/public/javascripts/bloodhound.js"></script>
-  <script src="https://unpkg.com/accessible-typeahead@0.1.2"></script>
+  <script src="https://unpkg.com/accessible-typeahead@0.1.3"></script>
   <script src="https://unpkg.com/lodash@4.17.4" type="text/javascript"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>

--- a/app/views/includes/location_picker.html
+++ b/app/views/includes/location_picker.html
@@ -44,6 +44,7 @@
   background-color: #2b8cc4;
   border-color: #2b8cc4;
   color: white;
+  outline: none;
 }
 
 @media (min-width: 641px) {


### PR DESCRIPTION
- Don't show any results if query is 1 or less characters
- Better sorting (by direct match and starts with)
- Sync styling with latest from accessible-typeahead
- Display friendly paths by default
- Ignore dots when searching (for e.g. "u.k." or "u.s.a.")

TODO:

- [x] Update to latest version of accessible-typeahead