### PR TITLE
Example 6

### DIFF
--- a/app/views/includes/location_picker.html
+++ b/app/views/includes/location_picker.html
@@ -1,4 +1,4 @@
-{% macro macro(label, locale='en-GB', graph={}, reverseMap={}) %}
+{% macro macro(label, locale='en-GB', graph={}, reverseMap={}, showPaths=true) %}
 
 <div class="form-group">
   <label class="form-label-bold" for="location-select-dropdown">
@@ -33,7 +33,7 @@
   <script src="https://unpkg.com/ua-parser-js@0.7.12"></script>
   <script src="/public/javascripts/bloodhound.js"></script>
   <script src="https://unpkg.com/accessible-typeahead@0.2.1"></script>
-  <link rel="stylesheet" href="https://unpkg.com/accessible-typeahead@0.2.1/examples/styled.css"></script>
+  <link rel="stylesheet" href="https://unpkg.com/accessible-typeahead@0.2.1/examples/styled.css">
   <script src="https://unpkg.com/lodash@4.17.4" type="text/javascript"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
@@ -47,7 +47,7 @@
   <script type="text/babel">
     $(document).ready(function () {
       var preferredLocale = 'en-GB'
-      var showPaths = true
+      var showPaths = {{ showPaths }}
 
       function isCanonicalNode (node) {
         return node.meta.canonical
@@ -89,32 +89,90 @@
         }
       }
 
+      function indexOfLowerCase (str, prefix) {
+        return str.toLowerCase().indexOf(prefix.toLowerCase())
+      }
+
+      // Takes a canonical node with the path to reach it, and the typed in query.
+      // Returns the same node and path, with added weight based on a number of criteria.
+      // Higher weight means higher priority, so it should be ranked higher in the list.
+      function addWeight (canonicalNodeWithPath, query) {
+        const cnwp = canonicalNodeWithPath
+        cnwp.weight = 1
+
+        const name = presentableName(cnwp.node, preferredLocale)
+        const isUk = name === 'United Kingdom'
+        cnwp.weight += isUk ? 100000 : 0
+
+        const isExactMatch = name.toLowerCase() === query.toLowerCase()
+        cnwp.weight += isExactMatch ? 10000 : 0
+
+        const synonymIsExactMatch = cnwp.path
+          .map(pathNode => presentableName(pathNode.node, pathNode.locale))
+          .map(nameInPath => nameInPath.toLowerCase())
+          .indexOf(query.toLowerCase()) !== -1
+        cnwp.weight += synonymIsExactMatch ? 1000 : 0
+
+        const indexOfQuery = indexOfLowerCase(name, query)
+        const canonicalNameStartsWithQuery = indexOfQuery === 0
+        cnwp.weight += canonicalNameStartsWithQuery ? 100 : 0
+
+        const canonicalNameContainsQuery = indexOfQuery > 0
+        cnwp.weight += canonicalNameContainsQuery ? 10 : 0
+
+        // Longer paths mean canonical node is further from matched synonym, so rank it lower.
+        cnwp.weight += cnwp.path.length * -1
+
+        return cnwp
+      }
+
+      function byWeightAndThenAlphabetically (a, b) {
+        const aName = presentableName(a.node, preferredLocale)
+        const bName = presentableName(b.node, preferredLocale)
+        return (a.weight > b.weight)
+          ? -1
+          : (a.weight < b.weight)
+            ? 1
+            // Weights are equal, sort alphabetically by name.
+            : (aName < bName)
+              ? -1
+              : (aName > bName)
+                ? 1
+                : 0
+      }
+
       // Bloodhound gives us back a list of results that includes synonyms, typos,
       // endonyms and other things we don't want the user to see.
       // This function transforms those into a list of stable canonical country names.
-      function presentResults (rawResults) {
+      function presentResults (rawResults, query) {
         var nodesWithLocales = rawResults.map(r => reverseMap[r])
 
         var canonicalNodesWithPaths = nodesWithLocales.reduce((canonicalNodes, nwl) => {
           return canonicalNodes.concat(findCanonicalNodeWithPath(nwl.node, nwl.locale, []))
         }, [])
 
-        var presentableNodes = _.uniq(
-          canonicalNodesWithPaths.map(cnwp => {
-            var canonicalName = presentableName(cnwp.node, preferredLocale)
-            var pathToName = ''
-            if (showPaths && cnwp.path.length) {
-              var stableNamesInPath = cnwp.path
-                .filter(pathNode => pathNode.node.meta['stable-name'])
-                .map(pathNode => presentableName(pathNode.node, pathNode.locale))
-              var lastNode = stableNamesInPath.pop()
-              if (lastNode) {
-                pathToName = ` (${lastNode})`
-              }
+        const canonicalNodesWithPathsAndWeights = canonicalNodesWithPaths.map(cnwp => addWeight(cnwp, query))
+
+        canonicalNodesWithPathsAndWeights.sort(byWeightAndThenAlphabetically)
+
+        const uniqueNodesWithPathsAndWeights = _.uniqBy(canonicalNodesWithPathsAndWeights, (cnwp) => {
+          return presentableName(cnwp.node, preferredLocale)
+        })
+
+        var presentableNodes = uniqueNodesWithPathsAndWeights.map(cnwp => {
+          var canonicalName = presentableName(cnwp.node, preferredLocale)
+          var pathToName = ''
+          if (showPaths && cnwp.path.length) {
+            var stableNamesInPath = cnwp.path
+              .filter(pathNode => pathNode.node.meta['stable-name'])
+              .map(pathNode => presentableName(pathNode.node, pathNode.locale))
+            var lastNode = stableNamesInPath.pop()
+            if (lastNode) {
+              pathToName = ` (${lastNode})`
             }
-            return `${canonicalName}${pathToName}`
-          })
-        )
+          }
+          return `${canonicalName}${pathToName}`
+        })
 
         return presentableNodes
       }
@@ -135,18 +193,6 @@
 
       var id = 'location-select-box'
 
-      function sortExactMatchesFirst (data, query) {
-        data.sort((a, b) => a === query ? -1 : (b === query ? 1 : 0 ))
-      }
-
-      function startsWith (str, query) {
-        return str.toLowerCase().indexOf(query.toLowerCase()) === 0
-      }
-
-      function sortResultsByWordMatch (data, query) {
-        data.sort((a, b) => startsWith(a, query) ? -1 : (startsWith(b, query) ? 1 : 0))
-      }
-
       AccessibleTypeahead({
         element: container[0],
         id: id,
@@ -157,11 +203,7 @@
           } else {
             query = query.replace(/\./g,'')
             countries.search(query, (rawResults) => {
-              sortExactMatchesFirst(rawResults, query)
-
-              var presentableResults = presentResults(rawResults)
-
-              sortResultsByWordMatch(presentableResults, query)
+              var presentableResults = presentResults(rawResults, query)
 
               syncResults(presentableResults)
             })
@@ -173,10 +215,6 @@
       label.attr('for', id)
 
       select.hide()
-
-      $('#location-show-paths').on('change', (evt) => {
-        showPaths = evt.target.checked
-      })
     })
   </script>
 {% endmacro %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -96,7 +96,8 @@ Location Picker Prototypes
       <h2 class="heading-medium"><a href="/location-picker-6">Example 6: Accessible Typeahead v0.2.1 + full register data v2 + weighting</a></h2>
 
       <p>
-        TODO
+        This example updates the version of the typeahead. It adds weighting to sort
+        results by their type of match, and then alphabetically.
       </p>
 
     </div>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -38,7 +38,7 @@ Location Picker Prototypes
        Collect which country a charity has most recently operated in.
       </p>
 
-      
+
 
       <h2 class="heading-large">Code</h2>
 
@@ -84,7 +84,7 @@ Location Picker Prototypes
         browsers, has some minor usability fixes, and uses a much larger dataset.
       </p>
 
-      <h2 class="heading-medium"><a href="/location-picker-5">Example 5: Custom Typeahead v0.1.2 + full register data v2</a></h2>
+      <h2 class="heading-medium"><a href="/location-picker-5">Example 5: Accessible Typeahead v0.1.2 + full register data v2</a></h2>
 
       <p>
         This example uses a version of a <a href="https://github.com/alphagov/accessible-typeahead" target="_blank">custom built typeahead that focuses on accessibility</a>.
@@ -93,7 +93,7 @@ Location Picker Prototypes
         territories and synonyms.
       </p>
 
-      <h2 class="heading-medium"><a href="/location-picker-6">Example 6: Custom Typeahead v0.2.0 + full register data v2 + weighting</a></h2>
+      <h2 class="heading-medium"><a href="/location-picker-6">Example 6: Accessible Typeahead v0.2.1 + full register data v2 + weighting</a></h2>
 
       <p>
         TODO

--- a/app/views/location-picker-6.html
+++ b/app/views/location-picker-6.html
@@ -47,24 +47,6 @@
         <input type="submit" class="button" value="Parhau">
       {% endif %}
     </div>
-
-    <h2 class="heading-large">Debugging options</h2>
-
-    <p>
-      {% if locale === 'en-GB' %}
-        <a href="/location-picker-5.cy" lang="cy" hreflang="cy">Fersiwn Cymraeg o'r dudalen hon</a>
-      {% else %}
-        <a href="/location-picker-5" lang="en" hreflang="en">English version of this page</a>
-      {% endif %}
-    </p>
-
-    <div class="form-group">
-      <label class="block-label selection-button-checkbox" for="location-show-paths">
-        <input id="location-show-paths" name="show-paths" type="checkbox" value="show-paths">
-        Show paths (useful for debugging, will cause duplicate countries to appear where more than one path exists)
-      </label>
-    </div>
-
   </form>
 
 </main>
@@ -259,10 +241,6 @@
       label.attr('for', id)
 
       select.hide()
-
-      $('#location-show-paths').on('change', (evt) => {
-        showPaths = evt.target.checked
-      })
     })
   </script>
 {% endblock %}

--- a/app/views/location-picker-6.html
+++ b/app/views/location-picker-6.html
@@ -91,7 +91,7 @@
   <script type="text/babel">
     $(document).ready(function () {
       var preferredLocale = 'en-GB'
-      var showPaths = false
+      var showPaths = true
 
       function isCanonicalNode (node) {
         return node.meta.canonical
@@ -148,8 +148,13 @@
             var canonicalName = presentableName(cnwp.node, preferredLocale)
             var pathToName = ''
             if (showPaths && cnwp.path.length) {
-              var stableNamesInPath = cnwp.path.map(pathNode => presentableName(pathNode.node, pathNode.locale))
-              pathToName = ` (path: ${stableNamesInPath.join(' > ')})`
+              var stableNamesInPath = cnwp.path
+                .filter(pathNode => pathNode.node.meta['stable-name'])
+                .map(pathNode => presentableName(pathNode.node, pathNode.locale))
+              var lastNode = stableNamesInPath.pop()
+              if (lastNode) {
+                pathToName = ` (${lastNode})`
+              }
             }
             return `${canonicalName}${pathToName}`
           })
@@ -178,10 +183,17 @@
         element: container[0],
         id: id,
         source: (query, syncResults) => {
-          countries.search(query, (rawResults) => {
-            var presentableResults = presentResults(rawResults)
-            syncResults(presentableResults)
-          })
+          const showNoResults = query.length <= 1
+          if (showNoResults) {
+            syncResults([])
+          } else {
+            query = query.replace(/\./g,'')
+            countries.search(query, (rawResults) => {
+              var presentableResults = presentResults(rawResults)
+
+              syncResults(presentableResults)
+            })
+          }
         }
       })
 

--- a/app/views/location-picker-6.html
+++ b/app/views/location-picker-6.html
@@ -76,8 +76,8 @@
   <!-- GOV.UK Prototype kit {{releaseVersion}} -->
 
   <script src="/public/javascripts/bloodhound.js"></script>
-  <script src="https://unpkg.com/accessible-typeahead@0.2.0"></script>
-  <link href="https://unpkg.com/accessible-typeahead@0.2.0/examples/styled.css" rel="stylesheet">
+  <script src="https://unpkg.com/accessible-typeahead@0.2.1"></script>
+  <link href="https://unpkg.com/accessible-typeahead@0.2.1/examples/styled.css" rel="stylesheet">
   <script src="https://unpkg.com/lodash@4.17.4" type="text/javascript"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>

--- a/app/views/location-picker-6.html
+++ b/app/views/location-picker-6.html
@@ -199,7 +199,11 @@
 
         canonicalNodesWithPathsAndWeights.sort(byWeightAndThenAlphabetically)
 
-        var presentableNodes = canonicalNodesWithPathsAndWeights.map(cnwp => {
+        const uniqueNodesWithPathsAndWeights = _.uniqBy(canonicalNodesWithPathsAndWeights, (cnwp) => {
+          return presentableName(cnwp.node, preferredLocale)
+        })
+
+        var presentableNodes = uniqueNodesWithPathsAndWeights.map(cnwp => {
           var canonicalName = presentableName(cnwp.node, preferredLocale)
           var pathToName = ''
           if (showPaths && cnwp.path.length) {
@@ -214,9 +218,7 @@
           return `${canonicalName}${pathToName}`
         })
 
-        const uniquePresentableNodes = _.uniq(presentableNodes)
-
-        return uniquePresentableNodes
+        return presentableNodes
       }
 
       // The keys of the reverseMap represent all the names/synonyms/endonyms, so

--- a/app/views/location-picker-6.html
+++ b/app/views/location-picker-6.html
@@ -145,6 +145,9 @@
         cnwp.weight = 1
 
         const name = presentableName(cnwp.node, preferredLocale)
+        const isUk = name === 'United Kingdom'
+        cnwp.weight += isUk ? 100000 : 0
+
         const isExactMatch = name.toLowerCase() === query.toLowerCase()
         cnwp.weight += isExactMatch ? 10000 : 0
 

--- a/app/views/location-picker-6.html
+++ b/app/views/location-picker-6.html
@@ -133,18 +133,71 @@
         }
       }
 
+      function indexOfLowerCase (str, prefix) {
+        return str.toLowerCase().indexOf(prefix.toLowerCase())
+      }
+
+      // Takes a canonical node with the path to reach it, and the typed in query.
+      // Returns the same node and path, with added weight based on a number of criteria.
+      // Higher weight means higher priority, so it should be ranked higher in the list.
+      function addWeight (canonicalNodeWithPath, query) {
+        const cnwp = canonicalNodeWithPath
+        cnwp.weight = 1
+
+        const name = presentableName(cnwp.node, preferredLocale)
+        const isExactMatch = name.toLowerCase() === query.toLowerCase()
+        cnwp.weight += isExactMatch ? 10000 : 0
+
+        const synonymIsExactMatch = cnwp.path
+          .map(pathNode => presentableName(pathNode.node, pathNode.locale))
+          .map(nameInPath => nameInPath.toLowerCase())
+          .indexOf(query.toLowerCase()) !== -1
+        cnwp.weight += synonymIsExactMatch ? 1000 : 0
+
+        const indexOfQuery = indexOfLowerCase(name, query)
+        const canonicalNameStartsWithQuery = indexOfQuery === 0
+        cnwp.weight += canonicalNameStartsWithQuery ? 100 : 0
+
+        const canonicalNameContainsQuery = indexOfQuery > 0
+        cnwp.weight += canonicalNameContainsQuery ? 10 : 0
+
+        // Longer paths mean canonical node is further from matched synonym, so rank it lower.
+        cnwp.weight += cnwp.path.length * -1
+
+        return cnwp
+      }
+
+      function byWeightAndThenAlphabetically (a, b) {
+        const aName = presentableName(a.node, preferredLocale)
+        const bName = presentableName(b.node, preferredLocale)
+        return (a.weight > b.weight)
+          ? -1
+          : (a.weight < b.weight)
+            ? 1
+            // Weights are equal, sort alphabetically by name.
+            : (aName < bName)
+              ? -1
+              : (aName > bName)
+                ? 1
+                : 0
+      }
+
       // Bloodhound gives us back a list of results that includes synonyms, typos,
       // endonyms and other things we don't want the user to see.
       // This function transforms those into a list of stable canonical country names.
-      function presentResults (rawResults) {
+      function presentResults (rawResults, query) {
         var nodesWithLocales = rawResults.map(r => reverseMap[r])
 
         var canonicalNodesWithPaths = nodesWithLocales.reduce((canonicalNodes, nwl) => {
           return canonicalNodes.concat(findCanonicalNodeWithPath(nwl.node, nwl.locale, []))
         }, [])
 
+        const canonicalNodesWithPathsAndWeights = canonicalNodesWithPaths.map(cnwp => addWeight(cnwp, query))
+
+        canonicalNodesWithPathsAndWeights.sort(byWeightAndThenAlphabetically)
+
         var presentableNodes = _.uniq(
-          canonicalNodesWithPaths.map(cnwp => {
+          canonicalNodesWithPathsAndWeights.map(cnwp => {
             var canonicalName = presentableName(cnwp.node, preferredLocale)
             var pathToName = ''
             if (showPaths && cnwp.path.length) {
@@ -189,7 +242,7 @@
           } else {
             query = query.replace(/\./g,'')
             countries.search(query, (rawResults) => {
-              var presentableResults = presentResults(rawResults)
+              var presentableResults = presentResults(rawResults, query)
 
               syncResults(presentableResults)
             })

--- a/app/views/location-picker-6.html
+++ b/app/views/location-picker-6.html
@@ -199,24 +199,24 @@
 
         canonicalNodesWithPathsAndWeights.sort(byWeightAndThenAlphabetically)
 
-        var presentableNodes = _.uniq(
-          canonicalNodesWithPathsAndWeights.map(cnwp => {
-            var canonicalName = presentableName(cnwp.node, preferredLocale)
-            var pathToName = ''
-            if (showPaths && cnwp.path.length) {
-              var stableNamesInPath = cnwp.path
-                .filter(pathNode => pathNode.node.meta['stable-name'])
-                .map(pathNode => presentableName(pathNode.node, pathNode.locale))
-              var lastNode = stableNamesInPath.pop()
-              if (lastNode) {
-                pathToName = ` (${lastNode})`
-              }
+        var presentableNodes = canonicalNodesWithPathsAndWeights.map(cnwp => {
+          var canonicalName = presentableName(cnwp.node, preferredLocale)
+          var pathToName = ''
+          if (showPaths && cnwp.path.length) {
+            var stableNamesInPath = cnwp.path
+              .filter(pathNode => pathNode.node.meta['stable-name'])
+              .map(pathNode => presentableName(pathNode.node, pathNode.locale))
+            var lastNode = stableNamesInPath.pop()
+            if (lastNode) {
+              pathToName = ` (${lastNode})`
             }
-            return `${canonicalName}${pathToName}`
-          })
-        )
+          }
+          return `${canonicalName}${pathToName}`
+        })
 
-        return presentableNodes
+        const uniquePresentableNodes = _.uniq(presentableNodes)
+
+        return uniquePresentableNodes
       }
 
       // The keys of the reverseMap represent all the names/synonyms/endonyms, so


### PR DESCRIPTION
It currently sorts by:
- Exact match of canonical name (United Kingdom -> United Kingdom)
- Exact match of synonym (uk -> United Kingdom (uk))
- If the canonical name starts with the query (Ge -> Germany)
- If the canonical name contains the query (king -> United Kingdom)

When weights are tied, they're sorted alphabetically.

TODO:

- [x] Review this with @edwardhorsford 
- [x] Add higher score for UK
- [x] Only show one result per country
- [x] Add option to display paths
- [x] Update `includes/location_picker.html`