### PR TITLE
Update latest picker

### DIFF
--- a/app/views/location-picker-6.html
+++ b/app/views/location-picker-6.html
@@ -58,8 +58,8 @@
   <!-- GOV.UK Prototype kit {{releaseVersion}} -->
 
   <script src="/public/javascripts/bloodhound.js"></script>
-  <script src="https://unpkg.com/accessible-typeahead@0.2.2"></script>
-  <link href="https://unpkg.com/accessible-typeahead@0.2.2/examples/styled.css" rel="stylesheet">
+  <script src="https://unpkg.com/accessible-typeahead@0.2.3"></script>
+  <link href="https://unpkg.com/accessible-typeahead@0.2.3/examples/styled.css" rel="stylesheet">
   <script src="https://unpkg.com/lodash@4.17.4" type="text/javascript"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
@@ -222,6 +222,7 @@
       AccessibleTypeahead({
         element: container[0],
         id: id,
+        minLength: 2,
         source: (query, syncResults) => {
           const showNoResults = query.length <= 1
           if (showNoResults) {


### PR DESCRIPTION
Bump version to 0.2.3, in prep for DAC, which allows us to use the `minLength` property.